### PR TITLE
Update sync process with watermelon

### DIFF
--- a/src/components/CustomLoadingSpinner/CustomLoadingSpinner.tsx
+++ b/src/components/CustomLoadingSpinner/CustomLoadingSpinner.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { View, ActivityIndicator } from 'react-native';
+
+type Props = {}
+
+const CustomLoadingSpinner = (props: Props) => {
+  return (
+    <View style={{flex: 1, justifyContent: "center"}}>
+      <ActivityIndicator size="small" color="#24c38b" />
+    </View>
+  );
+}
+
+export default CustomLoadingSpinner;

--- a/src/migrations/table-schemas/issue.ts
+++ b/src/migrations/table-schemas/issue.ts
@@ -1,9 +1,6 @@
 import { tableSchema, TableSchema } from "@nozbe/watermelondb";
 import { TABLE_NAMES } from "../tableName";
 
-//funcionó con watermelon el retrieve local y update local - cambiando un issue y su issue_status
-// 7:09 - 12:38 | 1:25 - 1:40 | 3:04 - 7:23
-// updated_date
 export const issueTableSchema: TableSchema = tableSchema({
   name: TABLE_NAMES.issue,
   columns: [

--- a/src/repositories/local/issues/IssueLocalRepository.ts
+++ b/src/repositories/local/issues/IssueLocalRepository.ts
@@ -31,32 +31,11 @@ export class IssueLocalRepository extends BaseLocalRepository<Issue> {
   fromLocalToRemote(localModel: IssueLocalModel): Issue {
 
     const parseJson = (jsonString: string | null): any => {
-      console.log(`PARSER STEP 1 - if null, it is an empty field at watermelon (review it)`, jsonString);
       try {
-        const parsedJson = jsonString
-          ? JSON.parse(JSON.stringify(jsonString), (key, value) => {
-              if (typeof value === 'string') {
-                // Try to parse ISO date strings to Date or Moment
-                const isoDateRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z?$/;
-                if (isoDateRegex.test(value)) {
-                  return moment(value);
-                }
-              }
-              if (key === 'id') {
-                return String(value);
-              }
-
-              if (value === undefined) {
-                return null;
-              }
-              return value;
-            })
-          : null;
-        console.log('PARSER STEP 2', parsedJson);
-        return parseJson;
+        return jsonString ? JSON.parse(jsonString) : null;
       } catch (e) {
         console.error('Failed to parse JSON:', e);
-        return null;
+        return jsonString;
       }
     };
 
@@ -66,7 +45,7 @@ export class IssueLocalRepository extends BaseLocalRepository<Issue> {
       escalate_flag: localModel.escalate_flag,
       reject_flag: localModel.reject_flag,
       rating: localModel.rating,
-      escalation_reason: localModel.escalate_flag,
+      escalation_reason: localModel.escalation_reason,
       research_result: localModel.research_result,
       auto_increment_id: localModel.auto_increment_id,
       confirmed: localModel.confirmed,
@@ -83,18 +62,18 @@ export class IssueLocalRepository extends BaseLocalRepository<Issue> {
       intake_date: new Date(localModel.intake_date),
       issue_date: localModel.issue_date ? new Date(localModel.issue_date) : null,
       resolution_date: localModel.resolution_date ? new Date(localModel.resolution_date) : null,
-      administrative_region: localModel.administrative_region,
-      assignee: localModel.assignee,
-      attachments: localModel.attachments,
-      category: localModel.category,
-      citizen: localModel.citizen,
-      component: localModel.component,
-      contact_information: localModel.contact_information,
-      issue_sub_type: localModel.issue_sub_type,
-      issue_type: localModel.issue_type,
-      reporter: localModel.reporter,
-      sub_component: localModel.sub_component,
-      status: localModel.status,
+      administrative_region: parseJson(localModel.administrative_region),
+      assignee: parseJson(localModel.assignee),
+      attachments: parseJson(localModel.attachments),
+      category: parseJson(localModel.category),
+      citizen: parseJson(localModel.citizen),
+      component: parseJson(localModel.component),
+      contact_information: parseJson(localModel.contact_information),
+      issue_sub_type: parseJson(localModel.issue_sub_type),
+      issue_type: parseJson(localModel.issue_type),
+      reporter: parseJson(localModel.reporter),
+      sub_component: parseJson(localModel.sub_component),
+      status: parseJson(localModel.status),
     };
   }
 }

--- a/src/repositories/remote/issues/IssueCommentRemoteRepository.ts
+++ b/src/repositories/remote/issues/IssueCommentRemoteRepository.ts
@@ -37,12 +37,13 @@ class IssueCommentRemoteRepository extends BaseRemoteRepository<IssueComment> {
     }
 
     async fetchAll(
+        endpointType: string | null,
         sortBy: string | null,
         sortOrder: SortOrder | null,
         limit: number | null,
-        createdAt: string | null,
-        updatedAt: string | null,
-        deletedAt: string | null,
+        created_date: EpochTimeStamp | null,
+        updated_date: EpochTimeStamp | null,
+        deleted_date: EpochTimeStamp | null,
         parentId: string | null,
     ): Promise<IssueComment[]> {
         const url = `${this.baseUrl}/${parentId}/comments/`;

--- a/src/repositories/remote/issues/IssueRemoteRepository.ts
+++ b/src/repositories/remote/issues/IssueRemoteRepository.ts
@@ -2,31 +2,10 @@ import { SortOrder } from '@nozbe/watermelondb/QueryDescription';
 import { Issue } from '../../../models/issues/Issue';
 import request from '../../../utils/request';
 import { BaseRemoteRepository } from '../../shared/BaseRemoteRepository';
+import config from '../../../../config';
 
 export class IssueRemoteRepository extends BaseRemoteRepository<Issue> {
   private baseUrl = `${config.API_AUTH_BASE_URL}/issues`;
-
-  fromRemoteToLocal(issue: any, index): any {
-
-    
-    if (issue && typeof issue === 'object') {
-      const i = issue as Record<string, any>;
-      return {
-      ...i,
-      assignee: JSON.stringify(i.assignee),
-      category: JSON.stringify(i.category),
-      citizen: JSON.stringify(i.citizen),
-      component: JSON.stringify(i.component),
-      issue_sub_type: JSON.stringify(i.issue_sub_type),
-      issue_type: JSON.stringify(i.issue_type),
-      reporter: JSON.stringify(i.reporter),
-      sub_component: JSON.stringify(i.sub_component),
-      status: JSON.stringify(i.status),
-      };
-    }
-    return null;
-  }
-
 
   /**
    * Fetch all issues from a dynamic endpoint.
@@ -132,7 +111,7 @@ export class IssueRemoteRepository extends BaseRemoteRepository<Issue> {
     const body = {
       escalate_flag: item.escalate_flag,
       reject_flag: item.reject_flag,
-      rating: item.rating,
+      rating: item.rating ?? undefined,
       escalation_reason: item.escalation_reason,
       research_result: item.research_result,
       status: item.status.id,

--- a/src/repositories/remote/issues/IssueRemoteRepository.ts
+++ b/src/repositories/remote/issues/IssueRemoteRepository.ts
@@ -1,8 +1,7 @@
-import { config } from '../../../../config.dev';
-import { BaseRemoteRepository } from '../../shared/BaseRemoteRepository';
-import { Issue, IssueLocalModel } from '../../../models/issues/Issue';
-import request from '../../../utils/request';
 import { SortOrder } from '@nozbe/watermelondb/QueryDescription';
+import { Issue } from '../../../models/issues/Issue';
+import request from '../../../utils/request';
+import { BaseRemoteRepository } from '../../shared/BaseRemoteRepository';
 
 export class IssueRemoteRepository extends BaseRemoteRepository<Issue> {
   private baseUrl = `${config.API_AUTH_BASE_URL}/issues`;
@@ -38,18 +37,18 @@ export class IssueRemoteRepository extends BaseRemoteRepository<Issue> {
     sortBy: string | null,
     sortOrder: SortOrder | null,
     limit: number | null,
-    created_date: string | null,
-    update_date: string | null,
-    deleted_date: string | null
+    created_date: EpochTimeStamp | null,
+    updated_date: EpochTimeStamp | null,
+    deleted_date: EpochTimeStamp | null
   ): Promise<Issue[]> {
     const params: Record<string, string> = {};
 
     if (sortBy) params.sortBy = sortBy;
     if (sortOrder) params.sortOrder = sortOrder;
     if (limit) params.limit = limit.toString();
-    if (created_date) params.created_date = created_date;
-    if (update_date) params.update_date = update_date;
-    if (deleted_date) params.deleted_date = deleted_date;
+    if (created_date) params.created_date = String(new Date(created_date).toISOString());
+    if (updated_date) params.updated_date = String(new Date(updated_date).toISOString());
+    // if (deleted_date) params.deleted_date = deleted_date;
 
     const url = `${this.baseUrl}/${endpointType}/`;
 

--- a/src/repositories/remote/issues/IssueRemoteRepository.ts
+++ b/src/repositories/remote/issues/IssueRemoteRepository.ts
@@ -42,13 +42,13 @@ export class IssueRemoteRepository extends BaseRemoteRepository<Issue> {
     deleted_date: EpochTimeStamp | null
   ): Promise<Issue[]> {
     const params: Record<string, string> = {};
-
+    
     if (sortBy) params.sortBy = sortBy;
     if (sortOrder) params.sortOrder = sortOrder;
     if (limit) params.limit = limit.toString();
     if (created_date) params.created_date = String(new Date(created_date).toISOString());
     if (updated_date) params.updated_date = String(new Date(updated_date).toISOString());
-    // if (deleted_date) params.deleted_date = deleted_date;
+    if (deleted_date) params.deleted_date = String(new Date(deleted_date).toISOString());
 
     const url = `${this.baseUrl}/${endpointType}/`;
 
@@ -100,7 +100,6 @@ export class IssueRemoteRepository extends BaseRemoteRepository<Issue> {
     const requestOptions = {
       url,
       method: 'POST',
-      params: new URLSearchParams({ page: '1', pageSize: '20' }),
       body: JSON.stringify(body),
     };
 
@@ -130,8 +129,6 @@ export class IssueRemoteRepository extends BaseRemoteRepository<Issue> {
   async update(id: string, item: Issue): Promise<Issue> {
     const url = `${this.baseUrl}/${id}/update/`;
 
-    console.log('UPDATE: ', item);
-
     const body = {
       escalate_flag: item.escalate_flag,
       reject_flag: item.reject_flag,
@@ -140,7 +137,6 @@ export class IssueRemoteRepository extends BaseRemoteRepository<Issue> {
       research_result: item.research_result,
       status: item.status.id,
     };
-    console.log('PATCH BODY', body);
 
     const requestOptions = {
       url,

--- a/src/repositories/shared/BaseRemoteRepository.ts
+++ b/src/repositories/shared/BaseRemoteRepository.ts
@@ -11,9 +11,9 @@ export abstract class BaseRemoteRepository<T> {
     sortBy: string | null,
     sortOrder: SortOrder | null,
     limit: number | null,
-    created_date: string | null,
-    update_date: string | null,
-    deleted_date: string | null
+    created_date: EpochTimeStamp | null,
+    updated_date: EpochTimeStamp | null,
+    deleted_date: EpochTimeStamp | null
   ): Promise<T[]>;
 
   abstract fetchById(id: string): Promise<T>;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -65,7 +65,7 @@ const Router = ({ theme }) => {
   {
 
       const checkSessionAndSync = async () => {
-        if (!syncServiceInstance.database && session) {
+        if (!syncServiceInstance.database && session?.token) {
           await initialSync();
           setLoading(false);
         } else {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -26,11 +26,13 @@ const Router = ({ theme }) => {
     return state.get("authentication").toObject();
   });
 
-  const getDBConfig = async () =>
+  const getSession = async () =>
   {
+    
+    
     const _session = await getSessionData();
-    if (_session) {
 
+    if (_session) {
       //
       //TODO: Delete after migrating to the new services, used for debugging purposes with old data.
       let dbCredentials;
@@ -51,8 +53,6 @@ const Router = ({ theme }) => {
       //
       //
 
-      await initialSync();
-
       dispatch(init(
         _session,
         { email: username }, dbCredentials  //TODO: Delete after migrating to the new services, used for debugging purposes with old data.
@@ -61,8 +61,23 @@ const Router = ({ theme }) => {
     setLoading(false);
   };
 
+  useEffect(() =>
+  {
+
+      const checkSessionAndSync = async () => {
+        if (!syncServiceInstance.database && session) {
+          await initialSync();
+          setLoading(false);
+        } else {
+          setLoading(false);
+        }
+      };
+      checkSessionAndSync();
+    
+  }, [session])
+  
   useEffect(() => {
-    getDBConfig();
+    getSession();
     const handleAppStateChange = (nextAppState) => {
       if (
         appState.current.match(/inactive|background/) &&
@@ -70,7 +85,7 @@ const Router = ({ theme }) => {
       ) {
         // App has come to the foreground, resume syncs
         try {
-          getDBConfig();
+          getSession();
         } catch (err) {
           console.warn('Error resuming syncs:', err);
         }

--- a/src/router/privateRoutes.js
+++ b/src/router/privateRoutes.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { View, ActivityIndicator } from 'react-native';
 import { createStackNavigator } from '@react-navigation/stack';
 import HomeRouter from '../screens/Home/';
 import { syncServiceInstance } from '../services/shared/SyncService';
@@ -22,24 +23,27 @@ const PrivateRoutes = () =>
     }
   }, []);
 
-  if (!dbReady) return <><Text>Loading database...</Text></>;
-    return (
-      <DatabaseProvider database={syncServiceInstance.database}>
-        <Stack.Navigator>
-          {/* //* Home */}
-          <Stack.Screen
-            options={{
-              headerShown: false,
-            }}
-            name="Main"
-            component={HomeRouter}
-          />
-          {/* /* Along with these would come any other route that wouldn't fit inside
+  if (!dbReady) return (<View style={{flex: 1, justifyContent: 'center'}}>
+    <ActivityIndicator size="small" color="#24c38b" />
+  </View>);
+  
+  return (
+    <DatabaseProvider database={syncServiceInstance.database}>
+      <Stack.Navigator>
+        {/* //* Home */}
+        <Stack.Screen
+          options={{
+            headerShown: false,
+          }}
+          name="Main"
+          component={HomeRouter}
+        />
+        {/* /* Along with these would come any other route that wouldn't fit inside
       the bottom tab navigator, meaning any view which doesn't display the tabs
       at the bottom of the screen. */}
-        </Stack.Navigator>
-      </DatabaseProvider>
-    );
+      </Stack.Navigator>
+    </DatabaseProvider>
+  );
 };
 
 export default PrivateRoutes;

--- a/src/router/privateRoutes.js
+++ b/src/router/privateRoutes.js
@@ -7,7 +7,22 @@ import { DatabaseProvider } from '@nozbe/watermelondb/react';
 const Stack = createStackNavigator();
 const PrivateRoutes = () =>
 {
-  if (!syncServiceInstance.database) return <></>
+  const [dbReady, setDbReady] = React.useState(!!syncServiceInstance.database);
+
+  React.useEffect(() => {
+    if (!syncServiceInstance.database) {
+      // Wait for the database to be initialized asynchronously
+      const checkDb = setInterval(() => {
+        if (syncServiceInstance.database) {
+          setDbReady(true);
+          clearInterval(checkDb);
+        }
+      }, 100);
+      return () => clearInterval(checkDb);
+    }
+  }, []);
+
+  if (!dbReady) return <><Text>Loading database...</Text></>;
     return (
       <DatabaseProvider database={syncServiceInstance.database}>
         <Stack.Navigator>

--- a/src/router/privateRoutes.js
+++ b/src/router/privateRoutes.js
@@ -25,7 +25,7 @@ const PrivateRoutes = () =>
     }
   }, []);
 
-  useEffect(() => {
+  React.useEffect(() => {
     let syncAllInterval;
 
     // Guard: clear any existing interval before setting a new one

--- a/src/router/privateRoutes.js
+++ b/src/router/privateRoutes.js
@@ -1,13 +1,12 @@
-import React from 'react';
-import { View, ActivityIndicator } from 'react-native';
+import { DatabaseProvider } from '@nozbe/watermelondb/react';
 import { createStackNavigator } from '@react-navigation/stack';
+import React from 'react';
+import CustomLoadingSpinner from '../components/CustomLoadingSpinner/CustomLoadingSpinner';
 import HomeRouter from '../screens/Home/';
 import { syncServiceInstance } from '../services/shared/SyncService';
-import { DatabaseProvider } from '@nozbe/watermelondb/react';
 
 const Stack = createStackNavigator();
-const PrivateRoutes = () =>
-{
+const PrivateRoutes = () => {
   const [dbReady, setDbReady] = React.useState(!!syncServiceInstance.database);
 
   React.useEffect(() => {
@@ -23,9 +22,7 @@ const PrivateRoutes = () =>
     }
   }, []);
 
-  if (!dbReady) return (<View style={{flex: 1, justifyContent: 'center'}}>
-    <ActivityIndicator size="small" color="#24c38b" />
-  </View>);
+  if (!dbReady) return <CustomLoadingSpinner />;
   
   return (
     <DatabaseProvider database={syncServiceInstance.database}>

--- a/src/router/privateRoutes.js
+++ b/src/router/privateRoutes.js
@@ -1,23 +1,30 @@
-import React from "react";
-import { createStackNavigator } from "@react-navigation/stack";
-import HomeRouter from "../screens/Home/";
+import React from 'react';
+import { createStackNavigator } from '@react-navigation/stack';
+import HomeRouter from '../screens/Home/';
+import { syncServiceInstance } from '../services/shared/SyncService';
+import { DatabaseProvider } from '@nozbe/watermelondb/react';
+
 const Stack = createStackNavigator();
-const PrivateRoutes = () => {
-  return (
-    <Stack.Navigator>
-      {/* //* Home */}
-      <Stack.Screen
-        options={{
-          headerShown: false,
-        }}
-        name="Main"
-        component={HomeRouter}
-      />
-      {/* /* Along with these would come any other route that wouldn't fit inside
+const PrivateRoutes = () =>
+{
+  if (!syncServiceInstance.database) return <></>
+    return (
+      <DatabaseProvider database={syncServiceInstance.database}>
+        <Stack.Navigator>
+          {/* //* Home */}
+          <Stack.Screen
+            options={{
+              headerShown: false,
+            }}
+            name="Main"
+            component={HomeRouter}
+          />
+          {/* /* Along with these would come any other route that wouldn't fit inside
       the bottom tab navigator, meaning any view which doesn't display the tabs
       at the bottom of the screen. */}
-    </Stack.Navigator>
-  );
+        </Stack.Navigator>
+      </DatabaseProvider>
+    );
 };
 
 export default PrivateRoutes;

--- a/src/router/privateRoutes.js
+++ b/src/router/privateRoutes.js
@@ -1,6 +1,6 @@
 import { DatabaseProvider } from '@nozbe/watermelondb/react';
 import { createStackNavigator } from '@react-navigation/stack';
-import React from 'react';
+import React, { useEffect } from 'react';
 import CustomLoadingSpinner from '../components/CustomLoadingSpinner/CustomLoadingSpinner';
 import HomeRouter from '../screens/Home/';
 import { syncServiceInstance } from '../services/shared/SyncService';
@@ -9,18 +9,37 @@ const Stack = createStackNavigator();
 const PrivateRoutes = () => {
   const [dbReady, setDbReady] = React.useState(!!syncServiceInstance.database);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!syncServiceInstance.database) {
       // Wait for the database to be initialized asynchronously
       const checkDb = setInterval(() => {
         if (syncServiceInstance.database) {
           setDbReady(true);
+          syncServiceInstance.syncAll();
           clearInterval(checkDb);
         }
       }, 100);
       return () => clearInterval(checkDb);
     }
   }, []);
+
+  useEffect(() => {
+    let syncAllInterval;
+
+    // Guard: clear any existing interval before setting a new one
+    if (dbReady) {
+      const SYNC_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+      syncAllInterval = setInterval(() => {
+        syncServiceInstance.syncAll();
+      }, SYNC_INTERVAL_MS);
+    }
+
+    return () => {
+      if (syncAllInterval) {
+        clearInterval(syncAllInterval);
+      }
+    };
+  }, [dbReady]);
 
   if (!dbReady) return <CustomLoadingSpinner />;
   

--- a/src/screens/Home/IssueActions/IssueActions.tsx
+++ b/src/screens/Home/IssueActions/IssueActions.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { SafeAreaView, Text } from 'react-native';
+import { SafeAreaView } from 'react-native';
 import { useSelector } from 'react-redux';
+import CustomLoadingSpinner from '../../../components/CustomLoadingSpinner/CustomLoadingSpinner';
+import { LocalAdminLevelsDatabase } from '../../../db/databaseManager';
+import { useIssue } from '../../../hooks/issues/useIssue';
+import { useIssueStatus } from '../../../hooks/issues/useIssueStatus';
 import Content from './containers/Content';
 import { styles } from './IssueActions.styles';
-import { LocalAdminLevelsDatabase } from '../../../db/databaseManager';
-import { useIssueStatus } from '../../../hooks/issues/useIssueStatus';
-import { useIssue } from '../../../hooks/issues/useIssue';
 
 function IssueActions({ route, navigation }) {
   const { params } = route;
@@ -46,17 +47,16 @@ function IssueActions({ route, navigation }) {
 
   if (loading) {
     return (
-      <SafeAreaView style={customStyles.container}>
-        <Text>loading...</Text>
-      </SafeAreaView>
+      <CustomLoadingSpinner />
     );
   }
-  
+
   return (
     <SafeAreaView style={customStyles.container}>
       <Content
         loading={loading}
         eadl={eadl}
+        session={session}
         currentIssue={params.item}
         navigation={navigation}
         statuses={issueStatusList}

--- a/src/screens/Home/IssueActions/containers/Content.tsx
+++ b/src/screens/Home/IssueActions/containers/Content.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { withObservables } from '@nozbe/watermelondb/react';
 import moment from 'moment';
-import React, { useEffect, useState } from 'react';
 import {
   KeyboardAvoidingView,
   Linking,

--- a/src/screens/Home/IssueActions/containers/Content.tsx
+++ b/src/screens/Home/IssueActions/containers/Content.tsx
@@ -488,6 +488,7 @@ function Content({ currentIssue, navigation, loading, statuses = [], eadl, updat
           whatsApp,
           _showDialog,
           isAcceptEnabled,
+          isIssueAssignedToMe,
           _showRejectDialog,
           rejectedDialog,
           hasActionsOrResolved,
@@ -607,6 +608,7 @@ function renderHeaderAndActions(
   whatsApp: () => void,
   _showDialog: () => void,
   isAcceptEnabled: boolean,
+  isIssueAssignedToMe: boolean,
   _showRejectDialog: () => void,
   rejectedDialog: boolean,
   hasActionsOrResolved: boolean,
@@ -676,12 +678,12 @@ function renderHeaderAndActions(
         <ActionButton
           label={i18n.t('accept_issue')}
           onShowDialog={_showDialog}
-          isEnabled={isAcceptEnabled}
+          isEnabled={isAcceptEnabled && isIssueAssignedToMe}
         />
         <ActionButton
           label={i18n.t('reject_issue')}
           onShowDialog={_showRejectDialog}
-          isEnabled={!hasActionsOrResolved || isAcceptEnabled}
+          isEnabled={(!hasActionsOrResolved || isAcceptEnabled) && isIssueAssignedToMe}
         />
         <ActionButton
           label={i18n.t('record_steps_taken')}
@@ -691,7 +693,7 @@ function renderHeaderAndActions(
         <ActionButton
           label={i18n.t('record_resolution')}
           onShowDialog={_showRecordResolutionDialog}
-          isEnabled={isRecordResolutionEnabled}
+          isEnabled={isRecordResolutionEnabled && isIssueAssignedToMe}
         />
       </View>
       <ActionButton

--- a/src/screens/Home/IssueActions/containers/Content.tsx
+++ b/src/screens/Home/IssueActions/containers/Content.tsx
@@ -52,6 +52,7 @@ const PHONE_CALL_LINK = 'tel://+223';
 type Props = {
   currentIssue: any;
   navigation: any;
+  session: any;
   loading: boolean;
   statuses: IssueStatus[];
   eadl: any;
@@ -59,7 +60,7 @@ type Props = {
   getStatus: (statusName: keyof IssueStatus) => IssueStatus;
 };
 
-function Content({ currentIssue, navigation, loading, statuses = [], eadl, updateIssue, getStatus }: Props) {
+function Content({ session, currentIssue, navigation, loading, statuses = [], eadl, updateIssue, getStatus }: Props) {
   const [issue, setIssue] = useState(currentIssue);
   const [acceptDialog, setAcceptDialog] = useState(false);
   const [rejectDialog, setRejectDialog] = useState(false);
@@ -460,7 +461,7 @@ function Content({ currentIssue, navigation, loading, statuses = [], eadl, updat
     if (loading) return;
     const isAssigned =
       issue.assignee?.id &&
-      (issue.reporter.id === issue.assignee.id || issue.assignee.id === eadl?._id);
+      (issue.reporter.id === issue.assignee.id || issue.assignee.id === session?.user_id);
     setIsIssueAssignedToMe(isAssigned);
 
     if (issue.citizen_type !== 1) {

--- a/src/services/issues/IssueStatusService.ts
+++ b/src/services/issues/IssueStatusService.ts
@@ -7,8 +7,6 @@ import { IssueStatus } from '../../models/issues/IssueStatus';
 import { TABLE_NAMES } from "../../migrations/tableName";
 import { Syncable } from '../shared/SyncService';
 
-console.log("REPOSITORY DEFINITION");
-
 const localRepository = new IssueStatusLocalRepository();
 const remoteRepository = new IssueStatusRemoteRepository();
   

--- a/src/services/shared/BaseService.ts
+++ b/src/services/shared/BaseService.ts
@@ -113,7 +113,7 @@ export class BaseService<T> {
 
     if (lastPulledAt != null) {
       try {
-        const updatedRecords = await this.remoteRepository.fetchAll(endPointType, null, null, null, null, lastPulledAt, null);
+        const updatedRecords = await this.remoteRepository.fetchAll(endPointType, null, null, null, null, lastPulledAt, null, null);
         const formattedRecords = updatedRecords.map((item) =>
           this.localRepository.fromRemoteToLocal(item)
         );

--- a/src/services/shared/BaseService.ts
+++ b/src/services/shared/BaseService.ts
@@ -91,10 +91,11 @@ export class BaseService<T> {
   }> {
     let changes = {};
     changes[tableName] = { created: [], updated: [], deleted: [] };
- 
+
     const timestamp = Date.now();
     const tableChanges = changes[tableName];
     //remove extra statuses , test status id match, convert ids to remote ids
+    
 
     // // 1. Fetch newly created records
     try {
@@ -115,8 +116,6 @@ export class BaseService<T> {
       console.error("Catch pulling created changes", e);
       tableChanges.created = []
     }
-    console.log(tableChanges.created.length);
-    
 
     // 2. Fetch updated records
     try {
@@ -181,47 +180,5 @@ export class BaseService<T> {
         await this.remoteRepository.delete(recordId);
       }
     }
-  }
-}
-
-export interface TableChangesAdapter {
-  // handles pulled changes
-  toLocal(changes: SyncTableChangeSet, database: Database): Promise<SyncTableChangeSet>;
-  // handles pushing changes
-  toRemote(changes: SyncTableChangeSet, database: Database): Promise<SyncTableChangeSet>;
-}
-
-export class HandleLocalRecordsAdapter implements TableChangesAdapter {
-  // if a server record has a localId, add the localId to deleted to delete local record
-  toLocal(changes: SyncTableChangeSet): Promise<SyncTableChangeSet> {
-    if (changes && changes.created) {
-      changes.created.forEach((record: DirtyRaw) => {
-        if (record.localId) {
-          if (!changes.deleted) {
-            changes.deleted = [];
-          }
-          changes.deleted.push(record.localId);
-        }
-        return record;
-      });
-    }
-    return Promise.resolve(changes);
-  }
-
-  // if a local record is created, add a localId to keep track of the record on the next pulling
-  toRemote(changes: SyncTableChangeSet): Promise<SyncTableChangeSet> {
-    if (changes && changes.created) {
-      changes = {
-        ...changes,
-        created: changes.created.map((record: DirtyRaw) => {
-          return {
-            ...record,
-            localId: record.id,
-            id: null, // use null to be compatible with non-string server id
-          };
-        }),
-        };
-    }
-    return Promise.resolve(changes);
   }
 }

--- a/src/services/shared/BaseService.ts
+++ b/src/services/shared/BaseService.ts
@@ -97,36 +97,43 @@ export class BaseService<T> {
     //remove extra statuses , test status id match, convert ids to remote ids
 
     // // 1. Fetch newly created records
-    const newRecords = await this.remoteRepository.fetchAll(
-      endPointType,
-      null,
-      null,
-      null,
-      lastPulledAt,
-      null,
-      null
-    );
-
-    const rawRecords = newRecords.map((item) => this.localRepository.fromRemoteToLocal(item));
-    console.log('formatted records', rawRecords[0]);
-    // response log: {"administrative_region": {"administrative_id": "1", "name": "sample administrative region"}, "assignee": "{\"id\":4,\"name\":\"Comité village Representative\"}", "category": "{\"id\":1,\"name\":\"sample category\"}", "citizen": undefined, "component": undefined, "id": 432432, "intake_date": "2025-08-19T00:51:27.330758Z", "issue_sub_type": undefined, "issue_type": "{\"id\":1,\"name\":\"type 1\"}", "reporter": "{\"id\":5,\"name\":\"Test Representative\"}", "status": "{\"id\":4,\"name\":\"Sample status 4\",\"final_status\":false,\"initial_status\":false,\"rejected_status\":true,\"open_status\":false}", "sub_component": undefined, "tracking_code": "string"}
-    // @ts-ignore
-    tableChanges.created = rawRecords.map((record) => {
-      return { ...record, id: String(record.id) };
-    });
-
-    console.log("TABLE NAME:", tableName, endPointType);
+    try {
+      const newRecords = await this.remoteRepository.fetchAll(
+        endPointType,
+        null,
+        null,
+        null,
+        lastPulledAt,
+        null,
+        null
+      );
+      const formattedRecords = newRecords.map((item) => this.localRepository.fromRemoteToLocal(item));
+      tableChanges.created = formattedRecords.map((record) => {
+        return { ...record, id: String(record.id) };
+      });
+    } catch (e) {
+      console.error("Catch pulling created changes", e);
+      tableChanges.created = []
+    }
     console.log(tableChanges.created.length);
     
 
     // 2. Fetch updated records
-    // const updatedRecords = []
-    // // const updatedRecords = await this.remoteRepository.fetchAll(endPointType, null, null, null, null, lastPulledAt, null);
-    // // @ts-ignore
-    // tableChanges.updated = updatedRecords.map((record) => ({
-    //   id:  String(record.id),
-    //   ...record,
-    // }));
+    try {
+      const updatedRecords = await this.remoteRepository.fetchAll(endPointType, null, null, null, null, lastPulledAt, null);
+      const formattedRecords = updatedRecords.map((item) =>
+        this.localRepository.fromRemoteToLocal(item)
+      );
+      tableChanges.updated = formattedRecords.map((record) => ({
+          ...record,
+          id:  String(record.id),
+        }
+      ));
+
+    } catch (error) {
+      console.error('Catch pulling updated changes', error);
+      tableChanges.updated = [];
+    }
 
     // // 3. Fetch deleted records (soft deletes are highly recommended for this)
     // const deletedRecords = await this.remoteRepository.fetchAll(

--- a/src/services/shared/BaseService.ts
+++ b/src/services/shared/BaseService.ts
@@ -1,8 +1,7 @@
 import NetInfo from '@react-native-community/netinfo';
 import { BaseLocalRepository } from '../../repositories/shared/BaseLocalRepository';
 import { BaseRemoteRepository } from '../../repositories/shared/BaseRemoteRepository';
-import type { Database, DirtyRaw, Model } from '@nozbe/watermelondb';
-import { SyncTableChangeSet } from '@nozbe/watermelondb/sync';
+import type { Model } from '@nozbe/watermelondb';
 import { RawRecord } from '@nozbe/watermelondb';
 import { TABLE_NAMES } from '../../migrations/tableName';
 
@@ -109,43 +108,49 @@ export class BaseService<T> {
         null
       );
       const formattedRecords = newRecords.map((item) => this.localRepository.fromRemoteToLocal(item));
-      tableChanges.created = formattedRecords.map((record) => {
-        return { ...record, id: String(record.id) };
-      });
+      tableChanges.created = formattedRecords.map((record) => ({
+          ...record,
+          id: String(record.id) 
+         }
+      ));
     } catch (e) {
       console.error("Catch pulling created changes", e);
       tableChanges.created = []
     }
 
     // 2. Fetch updated records
-    try {
-      const updatedRecords = await this.remoteRepository.fetchAll(endPointType, null, null, null, null, lastPulledAt, null);
-      const formattedRecords = updatedRecords.map((item) =>
-        this.localRepository.fromRemoteToLocal(item)
-      );
-      tableChanges.updated = formattedRecords.map((record) => ({
-          ...record,
-          id:  String(record.id),
-        }
-      ));
 
-    } catch (error) {
-      console.error('Catch pulling updated changes', error);
-      tableChanges.updated = [];
+    if (lastPulledAt != null) {
+      try {
+        const updatedRecords = await this.remoteRepository.fetchAll(endPointType, null, null, null, null, lastPulledAt, null);
+        const formattedRecords = updatedRecords.map((item) =>
+          this.localRepository.fromRemoteToLocal(item)
+        );
+        tableChanges.updated = formattedRecords.map((record) => ({
+            ...record,
+            id:  String(record.id),
+          }
+        ));
+  
+      } catch (error) {
+        console.error('Catch pulling updated changes', error);
+        tableChanges.updated = [];
+      }
+  
+      // // 3. Fetch deleted records (soft deletes are highly recommended for this)
+      // const deletedRecords = await this.remoteRepository.fetchAll(
+      //   endPointType,
+      //   null,
+      //   null,
+      //   null,
+      //   null,
+      //   null,
+      //   lastPulledAt
+      // );
+  
+      // Return all changes and the timestamp for the next pull
+      
     }
-
-    // // 3. Fetch deleted records (soft deletes are highly recommended for this)
-    // const deletedRecords = await this.remoteRepository.fetchAll(
-    //   endPointType,
-    //   null,
-    //   null,
-    //   null,
-    //   null,
-    //   null,
-    //   lastPulledAt
-    // );
-
-    // Return all changes and the timestamp for the next pull
     return { changes, timestamp };
   }
 
@@ -161,7 +166,8 @@ export class BaseService<T> {
     if (tableChanges.created.length > 0) {
       console.log(`Pushing ${tableChanges.created.length} new records to ${tableName}`);
       for (const record of tableChanges.created) {
-        await this.remoteRepository.create(record);
+        const modelInterface = this.localRepository.fromLocalToRemote(record);
+        await this.remoteRepository.create(modelInterface);
       }
     }
 
@@ -169,7 +175,8 @@ export class BaseService<T> {
     if (tableChanges.updated.length > 0) {
       console.log(`Pushing ${tableChanges.updated.length} updated records to ${tableName}`);
       for (const record of tableChanges.updated) {
-        await this.remoteRepository.update(record.id, record);
+        const modelInterface = this.localRepository.fromLocalToRemote(record);
+        await this.remoteRepository.update(modelInterface.id, modelInterface);
       }
     }
 

--- a/src/services/shared/SyncService.ts
+++ b/src/services/shared/SyncService.ts
@@ -88,7 +88,33 @@ export class SyncService {
           const timestamp = Date.now();
           for (const syncable of this.syncables) {
             const syncableChanges = await syncable.pullChanges({ tableName: syncable.tableName, lastPulledAt });
-            changes = {...syncableChanges.changes, ...changes }
+            // Create unique issue list from remote lists
+            if (changes && changes.issue) {
+              const createdUniqueArray = Array.from(
+                new Map(
+                  [...changes.issue.created, ...syncableChanges.changes.issue.created]
+                    .map((item) => [item.id, item])
+                ).values()
+              );
+              const updatedUniqueArray = Array.from(
+                new Map(
+                  [...changes.issue.updated, ...syncableChanges.changes.issue.updated]
+                    .map((item) => [item.id, item])
+                  ).values()
+              );
+              const deletedUniqueArray = Array.from(
+                new Map(
+                  [...changes.issue.deleted, ...syncableChanges.changes.issue.deleted]
+                    .map((item) => [item.id, item])
+                  ).values()
+              );
+              
+              changes = { ...changes, issue: { created: createdUniqueArray, updated: updatedUniqueArray, deleted: deletedUniqueArray } }
+              
+            } else {
+              changes = { ...syncableChanges.changes, ...changes }
+            }
+            
           }
           console.log(`🍉 Changes pulled successfully. Timestamp: ${timestamp}`);
 

--- a/src/services/shared/SyncService.ts
+++ b/src/services/shared/SyncService.ts
@@ -8,7 +8,6 @@ import { IssueStatusLocalModel } from "../../models/issues/IssueStatus";
 import { IssueLocalModel } from "../../models/issues/Issue";
 import { IssueTypeLocalModel } from "../../models/issues/IssueType";
 import { IssueCategoryLocalModel } from "../../models/issues/IssueCategory";
-import { SyncDatabaseChangeSet } from '@nozbe/watermelondb/sync';
 
 const DB_NAME = "grm-db";
 
@@ -82,12 +81,13 @@ export class SyncService {
 
     return await synchronize({
       database: this.database,
-        pullChanges: async ({ lastPulledAt }) => {
+        pullChanges: async ({ lastPulledAt, schemaVersion, migration }) => {
           console.log(`🍉 Pulling with lastPulledAt = ${lastPulledAt}`);
-          let changes = {};
+          let changes = {};          
           const timestamp = Date.now();
           for (const syncable of this.syncables) {
-            const syncableChanges = await syncable.pullChanges({ tableName: syncable.tableName, lastPulledAt });
+            const syncableChanges = await syncable.pullChanges({ tableName: syncable.tableName, lastPulledAt });            
+            
             // Create unique issue list from remote lists
             if (changes && changes.issue) {
               const createdUniqueArray = Array.from(
@@ -117,6 +117,7 @@ export class SyncService {
             
           }
           console.log(`🍉 Changes pulled successfully. Timestamp: ${timestamp}`);
+
 
           return { changes, timestamp };
         },

--- a/src/utils/networkMonitor.ts
+++ b/src/utils/networkMonitor.ts
@@ -21,7 +21,6 @@ export function registerServices(): void {
 
 async function setupConnectionWatcher(): Promise<void> {
   console.log('[Sync] Starting sync watcherListener');
-  await syncServiceInstance.syncAll(); //Debug
   if (watcherListener) return;
   console.log('[Sync] No sync watcherListener initialized');
   watcherListener = NetInfo.addEventListener((state) => {


### PR DESCRIPTION
Review sync process with watermelon

- Handled URLs from different sources to the same table.
- Added periodic sync.
- The appropriate format for `updated_date` and `created_date` was used as required by the new endpoints for listing items.
- Updated push changes handler from watermelon sync primitives.
 

created from #23 to test with real data